### PR TITLE
AI Code Agent: Create SmartFarm sample dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+out
+coverage
+dist
+*.tsbuildinfo
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+.ai-code-agent/

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+export default function Error({ reset }: { reset: () => void }) {
+  return (
+    <main className="page-shell">
+      <section className="hero-card">
+        <div>
+          <span className="eyebrow">SmartFarm demo</span>
+          <h1>Dashboard temporarily unavailable</h1>
+          <p>The SmartFarm preview hit an error while rendering sample monitoring data.</p>
+        </div>
+        <div className="hero-meta" style={{ width: '100%', justifyContent: 'flex-start', flexWrap: 'wrap', gap: '0.75rem' }}>
+          <div className="hero-pill">Error fallback</div>
+          <div className="hero-pill accent">Desktop + mobile support</div>
+        </div>
+      </section>
+
+      <section
+        className="state-panel error-state"
+        style={{
+          display: 'grid',
+          gap: '1rem',
+          background: 'linear-gradient(135deg, rgba(255, 247, 237, 0.98), rgba(254, 226, 226, 0.92))',
+          border: '1px solid rgba(239, 68, 68, 0.2)',
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '0.75rem',
+          }}
+        >
+          <div className="state-badge">error state</div>
+          <div className="hero-pill" style={{ background: 'rgba(239, 68, 68, 0.1)', color: '#991b1b' }}>
+            Responsive recovery
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gap: '0.75rem' }}>
+          <h2 style={{ margin: 0 }}>We couldn’t load the dashboard</h2>
+          <p style={{ margin: 0 }}>Please try again to re-render the route and restore the demo experience.</p>
+          <p style={{ margin: 0 }}>
+            This fallback keeps content readable in a single column on phones and within the full dashboard shell on larger screens.
+          </p>
+        </div>
+
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+            gap: '0.75rem',
+          }}
+        >
+          <div
+            style={{
+              padding: '0.95rem 1rem',
+              borderRadius: '18px',
+              background: 'rgba(255, 255, 255, 0.72)',
+              border: '1px solid rgba(239, 68, 68, 0.14)',
+            }}
+          >
+            <strong style={{ display: 'block', marginBottom: '0.35rem' }}>Alerts snapshot</strong>
+            <span>Warnings remain represented even when the dashboard cannot finish rendering.</span>
+          </div>
+          <div
+            style={{
+              padding: '0.95rem 1rem',
+              borderRadius: '18px',
+              background: 'rgba(255, 255, 255, 0.72)',
+              border: '1px solid rgba(239, 68, 68, 0.14)',
+            }}
+          >
+            <strong style={{ display: 'block', marginBottom: '0.35rem' }}>Layout coverage</strong>
+            <span>Cards stack on mobile and spread naturally across desktop widths.</span>
+          </div>
+        </div>
+
+        <button className="retry-button" onClick={reset} type="button">
+          Retry dashboard
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,87 +1,17 @@
-'use client';
+"use client";
 
-export default function Error({ reset }: { reset: () => void }) {
+type ErrorProps = {
+  error: Error;
+  reset: () => void;
+};
+
+export default function ErrorBoundary({ error, reset }: ErrorProps) {
   return (
-    <main className="page-shell">
-      <section className="hero-card">
-        <div>
-          <span className="eyebrow">SmartFarm demo</span>
-          <h1>Dashboard temporarily unavailable</h1>
-          <p>The SmartFarm preview hit an error while rendering sample monitoring data.</p>
-        </div>
-        <div className="hero-meta" style={{ width: '100%', justifyContent: 'flex-start', flexWrap: 'wrap', gap: '0.75rem' }}>
-          <div className="hero-pill">Error fallback</div>
-          <div className="hero-pill accent">Desktop + mobile support</div>
-        </div>
-      </section>
-
-      <section
-        className="state-panel error-state"
-        style={{
-          display: 'grid',
-          gap: '1rem',
-          background: 'linear-gradient(135deg, rgba(255, 247, 237, 0.98), rgba(254, 226, 226, 0.92))',
-          border: '1px solid rgba(239, 68, 68, 0.2)',
-        }}
-      >
-        <div
-          style={{
-            display: 'flex',
-            flexWrap: 'wrap',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            gap: '0.75rem',
-          }}
-        >
-          <div className="state-badge">error state</div>
-          <div className="hero-pill" style={{ background: 'rgba(239, 68, 68, 0.1)', color: '#991b1b' }}>
-            Responsive recovery
-          </div>
-        </div>
-
-        <div style={{ display: 'grid', gap: '0.75rem' }}>
-          <h2 style={{ margin: 0 }}>We couldn’t load the dashboard</h2>
-          <p style={{ margin: 0 }}>Please try again to re-render the route and restore the demo experience.</p>
-          <p style={{ margin: 0 }}>
-            This fallback keeps content readable in a single column on phones and within the full dashboard shell on larger screens.
-          </p>
-        </div>
-
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
-            gap: '0.75rem',
-          }}
-        >
-          <div
-            style={{
-              padding: '0.95rem 1rem',
-              borderRadius: '18px',
-              background: 'rgba(255, 255, 255, 0.72)',
-              border: '1px solid rgba(239, 68, 68, 0.14)',
-            }}
-          >
-            <strong style={{ display: 'block', marginBottom: '0.35rem' }}>Alerts snapshot</strong>
-            <span>Warnings remain represented even when the dashboard cannot finish rendering.</span>
-          </div>
-          <div
-            style={{
-              padding: '0.95rem 1rem',
-              borderRadius: '18px',
-              background: 'rgba(255, 255, 255, 0.72)',
-              border: '1px solid rgba(239, 68, 68, 0.14)',
-            }}
-          >
-            <strong style={{ display: 'block', marginBottom: '0.35rem' }}>Layout coverage</strong>
-            <span>Cards stack on mobile and spread naturally across desktop widths.</span>
-          </div>
-        </div>
-
-        <button className="retry-button" onClick={reset} type="button">
-          Retry dashboard
-        </button>
-      </section>
-    </main>
+    <div style={{ padding: "2rem", borderRadius: "24px", background: "#fffaf0", color: "#1f2937" }}>
+      <h2>Something interrupted the signal feed</h2>
+      <p style={{ color: "#5b6470" }}>The page is intact, but the live content could not be refreshed just now.</p>
+      <p style={{ color: "#b91c1c" }}>{error.message}</p>
+      <button type="button" onClick={reset} style={{ marginTop: "1rem" }}>Try again</button>
+    </div>
   );
 }

--- a/app/github/error.tsx
+++ b/app/github/error.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+type ErrorProps = {
+  error: Error;
+  reset: () => void;
+};
+
+export default function ErrorBoundary({ error, reset }: ErrorProps) {
+  return (
+    <div style={{ padding: "2rem", borderRadius: "24px", background: "#fffaf0", color: "#1f2937" }}>
+      <h2>Something interrupted the signal feed</h2>
+      <p style={{ color: "#5b6470" }}>The page is intact, but the live content could not be refreshed just now.</p>
+      <p style={{ color: "#b91c1c" }}>{error.message}</p>
+      <button type="button" onClick={reset} style={{ marginTop: "1rem" }}>Try again</button>
+    </div>
+  );
+}

--- a/app/github/loading.tsx
+++ b/app/github/loading.tsx
@@ -1,0 +1,7 @@
+export default function Loading() {
+  return (
+    <div style={{ minHeight: "40vh", display: "grid", placeItems: "center", padding: "2rem", borderRadius: "24px", background: "#fffaf0", color: "#5b6470" }}>
+      <p>Loading the latest signals and arranging the board.</p>
+    </div>
+  );
+}

--- a/app/github/page.tsx
+++ b/app/github/page.tsx
@@ -1,0 +1,27 @@
+import { GreenhouseOverviewSection } from "../../components/greenhouse-overview-section";
+
+const previewItems = [
+  { label: "Primary signal", value: "$128k", detail: "Net uplift since the last release window." },
+  { label: "Momentum", value: "+18%", detail: "Week-on-week momentum across the main surface." },
+];
+
+const pageStyles = {
+  shell: { minHeight: "100vh", padding: "4rem 1.5rem", background: "linear-gradient(180deg, #f5efe4 0%, #ebe4d8 100%)", color: "#1f2937" },
+  hero: { maxWidth: "56rem", margin: "0 auto 2rem", padding: "2rem", borderRadius: "28px", background: "#fffaf0", boxShadow: "0 24px 60px rgba(15, 23, 42, 0.12)" },
+  eyebrow: { margin: 0, textTransform: "uppercase", letterSpacing: "0.18em", fontSize: "0.72rem", color: "#0f766e" },
+  title: { margin: "0.75rem 0 0", fontSize: "clamp(2.5rem, 6vw, 4.75rem)", lineHeight: 0.95 },
+  description: { maxWidth: "42rem", margin: "1rem 0 0", fontSize: "1.05rem", color: "#5b6470" },
+};
+
+export default function GithubPage() {
+  return (
+    <main style={pageStyles.shell}>
+      <section style={pageStyles.hero}>
+        <p style={pageStyles.eyebrow}>Signal-rich dashboard</p>
+        <h1 style={pageStyles.title}>Github</h1>
+        <p style={pageStyles.description}>A bold control room layout with clear hierarchy, warm surfaces, and decisive contrast.</p>
+      </section>
+      <GreenhouseOverviewSection state="ready" items={previewItems} />
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,377 @@
+:root {
+  --bg: #f7f1e8;
+  --bg-accent: #efe1cc;
+  --surface: rgba(255, 252, 247, 0.88);
+  --surface-strong: #fffaf2;
+  --border: rgba(121, 92, 58, 0.14);
+  --text: #2f2417;
+  --muted: #72604a;
+  --primary: #8d5b2b;
+  --primary-soft: #e8cfae;
+  --success: #3c7a4b;
+  --warning: #b97716;
+  --danger: #b44a3f;
+  --shadow: 0 18px 45px rgba(88, 56, 23, 0.12);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Arial, Helvetica, sans-serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at top, rgba(255, 245, 225, 0.9), transparent 35%),
+    linear-gradient(180deg, #fcf7ef 0%, var(--bg) 100%);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+}
+
+.page-shell {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+
+.hero-card,
+.panel,
+.metric-card,
+.state-panel,
+.state-demo-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(10px);
+}
+
+.hero-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 28px;
+  margin-bottom: 24px;
+  background: linear-gradient(135deg, rgba(255, 249, 239, 0.95), rgba(243, 227, 201, 0.9));
+}
+
+.hero-card h1 {
+  margin: 8px 0 10px;
+  font-size: clamp(2rem, 3vw, 3rem);
+  line-height: 1.05;
+}
+
+.hero-card p {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(141, 91, 43, 0.12);
+  color: var(--primary);
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 10px;
+}
+
+.hero-pill,
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.9rem;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(121, 92, 58, 0.12);
+  text-transform: capitalize;
+}
+
+.hero-pill.accent {
+  background: rgba(60, 122, 75, 0.12);
+  color: var(--success);
+}
+
+.state-showcase {
+  display: grid;
+  gap: 24px;
+}
+
+.state-demo-card {
+  padding: 22px;
+}
+
+.state-demo-header {
+  margin-bottom: 18px;
+}
+
+.state-demo-header h2 {
+  margin: 12px 0 8px;
+  font-size: 1.5rem;
+}
+
+.state-demo-header p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.dashboard-stack {
+  display: grid;
+  gap: 24px;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.metric-card {
+  padding: 20px;
+}
+
+.metric-card h3,
+.panel h2,
+.state-panel h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.metric-value {
+  margin: 12px 0 8px;
+  font-size: 2rem;
+  font-weight: 800;
+}
+
+.metric-trend {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.metric-status {
+  margin-top: 14px;
+}
+
+.badge.good,
+.badge.stable,
+.badge.optimal,
+.badge.info {
+  color: var(--success);
+  background: rgba(60, 122, 75, 0.12);
+}
+
+.badge.warning,
+.badge.attention,
+.badge.empty {
+  color: var(--warning);
+  background: rgba(185, 119, 22, 0.14);
+}
+
+.badge.error {
+  color: var(--danger);
+  background: rgba(180, 74, 63, 0.14);
+}
+
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: 24px;
+}
+
+.panel {
+  padding: 22px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  margin-bottom: 18px;
+}
+
+.panel-subtitle {
+  margin: 8px 0 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.list {
+  display: grid;
+  gap: 14px;
+}
+
+.alert-item,
+.zone-item,
+.empty-block {
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--surface-strong);
+}
+
+.alert-item,
+.zone-item {
+  padding: 16px;
+}
+
+.alert-top,
+.zone-top {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+}
+
+.alert-item h3,
+.zone-item h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.alert-item p,
+.zone-meta,
+.empty-block p,
+.state-panel p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.zone-stats {
+  margin-top: 14px;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.zone-stat {
+  padding: 12px;
+  border-radius: 14px;
+  background: rgba(239, 225, 204, 0.45);
+}
+
+.zone-stat-label {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+
+.zone-stat-value {
+  font-weight: 700;
+}
+
+.state-panel {
+  padding: 28px;
+  text-align: center;
+}
+
+.loading-state,
+.error-state {
+  display: grid;
+  justify-items: center;
+  gap: 12px;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 4px solid rgba(141, 91, 43, 0.18);
+  border-top-color: var(--primary);
+  animation: spin 0.9s linear infinite;
+}
+
+.empty-block {
+  padding: 18px;
+}
+
+.retry-button {
+  padding: 12px 18px;
+  border: 0;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #fffaf2;
+  cursor: pointer;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (max-width: 1024px) {
+  .metrics-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .page-shell {
+    width: min(100% - 20px, 1200px);
+    padding: 20px 0 36px;
+  }
+
+  .hero-card {
+    flex-direction: column;
+    padding: 22px;
+  }
+
+  .hero-meta {
+    align-items: flex-start;
+  }
+
+  .metrics-grid,
+  .zone-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .alert-top,
+  .zone-top,
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .state-demo-card,
+  .panel,
+  .metric-card,
+  .state-panel {
+    padding: 18px;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'SmartFarm Dashboard',
+  description: 'A demo-ready SmartFarm monitoring dashboard built with Next.js.',
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,56 +1,7 @@
 export default function Loading() {
   return (
-    <main className="page-shell">
-      <section className="hero-card">
-        <div>
-          <span className="eyebrow">SmartFarm demo</span>
-          <h1>Loading dashboard…</h1>
-          <p>Preparing the latest greenhouse snapshot and alert feed.</p>
-        </div>
-        <div className="hero-meta" style={{ width: '100%', justifyContent: 'flex-start', flexWrap: 'wrap', gap: '0.75rem' }}>
-          <div className="hero-pill">Route loading</div>
-          <div className="hero-pill accent">Desktop + mobile ready</div>
-        </div>
-      </section>
-
-      <section className="summary-grid" aria-label="Loading metric cards">
-        {Array.from({ length: 5 }).map((_, index) => (
-          <div key={index} className="summary-card loading-block" style={{ minHeight: 132 }} />
-        ))}
-      </section>
-
-      <section className="dashboard-grid" aria-label="Loading dashboard sections">
-        <div className="dashboard-main" style={{ display: 'grid', gap: '1rem' }}>
-          <div className="dashboard-panel loading-block" style={{ minHeight: 320, width: '100%' }} />
-          <div className="dashboard-panel loading-block" style={{ minHeight: 260, width: '100%' }} />
-        </div>
-        <div className="dashboard-side" style={{ display: 'grid', gap: '1rem' }}>
-          <div className="dashboard-panel loading-block" style={{ minHeight: 320, width: '100%' }} />
-        </div>
-      </section>
-
-      <section
-        className="dashboard-panel"
-        aria-label="Responsive loading notes"
-        style={{ display: 'grid', gap: '0.75rem' }}
-      >
-        <div className="state-badge">loading state</div>
-        <h2 style={{ margin: 0 }}>Responsive preview in progress</h2>
-        <p style={{ margin: 0 }}>
-          Cards stack cleanly on narrow screens and expand into a dashboard layout on larger viewports.
-        </p>
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
-            gap: '0.75rem',
-          }}
-          aria-hidden="true"
-        >
-          <div className="loading-block" style={{ minHeight: 88, borderRadius: 18 }} />
-          <div className="loading-block" style={{ minHeight: 88, borderRadius: 18 }} />
-        </div>
-      </section>
-    </main>
+    <div style={{ minHeight: "40vh", display: "grid", placeItems: "center", padding: "2rem", borderRadius: "24px", background: "#fffaf0", color: "#5b6470" }}>
+      <p>Loading the latest signals and arranging the board.</p>
+    </div>
   );
 }

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,56 @@
+export default function Loading() {
+  return (
+    <main className="page-shell">
+      <section className="hero-card">
+        <div>
+          <span className="eyebrow">SmartFarm demo</span>
+          <h1>Loading dashboard…</h1>
+          <p>Preparing the latest greenhouse snapshot and alert feed.</p>
+        </div>
+        <div className="hero-meta" style={{ width: '100%', justifyContent: 'flex-start', flexWrap: 'wrap', gap: '0.75rem' }}>
+          <div className="hero-pill">Route loading</div>
+          <div className="hero-pill accent">Desktop + mobile ready</div>
+        </div>
+      </section>
+
+      <section className="summary-grid" aria-label="Loading metric cards">
+        {Array.from({ length: 5 }).map((_, index) => (
+          <div key={index} className="summary-card loading-block" style={{ minHeight: 132 }} />
+        ))}
+      </section>
+
+      <section className="dashboard-grid" aria-label="Loading dashboard sections">
+        <div className="dashboard-main" style={{ display: 'grid', gap: '1rem' }}>
+          <div className="dashboard-panel loading-block" style={{ minHeight: 320, width: '100%' }} />
+          <div className="dashboard-panel loading-block" style={{ minHeight: 260, width: '100%' }} />
+        </div>
+        <div className="dashboard-side" style={{ display: 'grid', gap: '1rem' }}>
+          <div className="dashboard-panel loading-block" style={{ minHeight: 320, width: '100%' }} />
+        </div>
+      </section>
+
+      <section
+        className="dashboard-panel"
+        aria-label="Responsive loading notes"
+        style={{ display: 'grid', gap: '0.75rem' }}
+      >
+        <div className="state-badge">loading state</div>
+        <h2 style={{ margin: 0 }}>Responsive preview in progress</h2>
+        <p style={{ margin: 0 }}>
+          Cards stack cleanly on narrow screens and expand into a dashboard layout on larger viewports.
+        </p>
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))',
+            gap: '0.75rem',
+          }}
+          aria-hidden="true"
+        >
+          <div className="loading-block" style={{ minHeight: 88, borderRadius: 18 }} />
+          <div className="loading-block" style={{ minHeight: 88, borderRadius: 18 }} />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,190 @@
+import { AlertsPanel, type AlertItem } from '../components/dashboard/alerts-panel';
+import { StateWrapper, type DemoState } from '../components/dashboard/state-wrapper';
+import { SummaryCards, type SummaryMetric } from '../components/dashboard/summary-cards';
+import { ZonesOverview, type FarmZone } from '../components/dashboard/zones-overview';
+
+const demoState: DemoState = 'success';
+
+const metrics: SummaryMetric[] = [
+  {
+    label: 'Temperature',
+    value: '24.8°C',
+    trend: '+1.2°C since dawn',
+    status: 'stable',
+  },
+  {
+    label: 'Humidity',
+    value: '68%',
+    trend: 'Ideal seedling range',
+    status: 'good',
+  },
+  {
+    label: 'Soil Moisture',
+    value: '41%',
+    trend: 'Sector B slightly low',
+    status: 'warning',
+  },
+  {
+    label: 'Water Tank',
+    value: '72%',
+    trend: 'Refill projected in 3 days',
+    status: 'good',
+  },
+  {
+    label: 'Device Status',
+    value: '18 / 20 online',
+    trend: '2 sensors need inspection',
+    status: 'warning',
+  },
+];
+
+const alerts: AlertItem[] = [
+  {
+    title: 'Soil moisture below target in Zone B',
+    detail: 'Moisture dropped to 32% over the last 2 hours.',
+    level: 'warning',
+    time: '10 min ago',
+  },
+  {
+    title: 'Nutrient pump delayed response',
+    detail: 'Pump 02 reported a slow activation cycle during the last run.',
+    level: 'warning',
+    time: '42 min ago',
+  },
+  {
+    title: 'Greenhouse 3 vent reopened',
+    detail: 'Vent system recovered after a brief temperature spike.',
+    level: 'info',
+    time: '1 hr ago',
+  },
+];
+
+const zones: FarmZone[] = [
+  {
+    name: 'Greenhouse A',
+    crop: 'Tomatoes',
+    temperature: '25°C',
+    moisture: 'Healthy',
+    irrigation: 'Scheduled 4:00 PM',
+    status: 'Optimal',
+  },
+  {
+    name: 'Greenhouse B',
+    crop: 'Leafy Greens',
+    temperature: '22°C',
+    moisture: 'Needs water',
+    irrigation: 'Priority queue',
+    status: 'Attention',
+  },
+  {
+    name: 'Orchard West',
+    crop: 'Citrus',
+    temperature: '27°C',
+    moisture: 'Balanced',
+    irrigation: 'Completed 8:15 AM',
+    status: 'Stable',
+  },
+  {
+    name: 'Nursery Bay',
+    crop: 'Seedlings',
+    temperature: '23°C',
+    moisture: 'Protected',
+    irrigation: 'Misting active',
+    status: 'Optimal',
+  },
+];
+
+const stateCopy: Record<DemoState, { title: string; message: string }> = {
+  loading: {
+    title: 'Loading SmartFarm dashboard',
+    message: 'Preparing the latest greenhouse snapshot and alert feed.',
+  },
+  empty: {
+    title: 'No SmartFarm data yet',
+    message: 'Connect sensors or add sample readings to populate this demo view.',
+  },
+  error: {
+    title: 'Dashboard preview unavailable',
+    message: 'We could not load the sample monitoring data. Try refreshing the demo.',
+  },
+  success: {
+    title: 'Farm operations are in view',
+    message: 'A live-style snapshot of climate, irrigation, and sensor activity across your farm.',
+  },
+};
+
+const stateOrder: DemoState[] = ['success', 'loading', 'empty', 'error'];
+
+function DashboardContent({ currentState }: { currentState: DemoState }) {
+  const currentAlerts = currentState === 'empty' ? [] : alerts;
+  const currentZones = currentState === 'empty' ? [] : zones;
+
+  return (
+    <StateWrapper
+      state={currentState}
+      emptyTitle="No live farm readings"
+      emptyMessage="Summary cards stay visible for context, while alerts and zones show how empty dashboard sections are presented."
+      errorTitle="Dashboard content unavailable"
+      errorMessage="This in-page example demonstrates an inline error state alongside route-level error boundaries."
+    >
+      <section className="dashboard-grid" aria-label="SmartFarm dashboard overview">
+        <div className="dashboard-main">
+          <SummaryCards metrics={metrics} />
+          {currentZones.length === 0 ? (
+            <section className="dashboard-panel">
+              <div className="empty-panel">
+                <strong>No zones configured</strong>
+                <p>Add greenhouses or irrigation zones to populate this overview.</p>
+              </div>
+            </section>
+          ) : (
+            <ZonesOverview zones={currentZones} />
+          )}
+        </div>
+        <div className="dashboard-side">
+          <AlertsPanel alerts={currentAlerts} />
+        </div>
+      </section>
+    </StateWrapper>
+  );
+}
+
+export default function Page() {
+  return (
+    <main className="page-shell">
+      <section className="hero-card">
+        <div>
+          <span className="eyebrow">SmartFarm demo</span>
+          <h1>{stateCopy[demoState].title}</h1>
+          <p>{stateCopy[demoState].message}</p>
+        </div>
+        <div className="hero-meta">
+          <div className="hero-pill">Primary mode: {demoState}</div>
+          <div className="hero-pill accent">Responsive sample dashboard</div>
+        </div>
+      </section>
+
+      <DashboardContent currentState={demoState} />
+
+      <section className="state-showcase" aria-label="Dashboard UI states showcase">
+        {stateOrder.map((state) => {
+          const copy = stateCopy[state];
+
+          return (
+            <article key={state} className="state-showcase-card">
+              <div className="panel-header">
+                <div>
+                  <span className="eyebrow">State preview</span>
+                  <h2>{copy.title}</h2>
+                </div>
+                <span className="hero-pill">{state}</span>
+              </div>
+              <p className="state-showcase-copy">{copy.message}</p>
+              <DashboardContent currentState={state} />
+            </article>
+          );
+        })}
+      </section>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,190 +1,27 @@
-import { AlertsPanel, type AlertItem } from '../components/dashboard/alerts-panel';
-import { StateWrapper, type DemoState } from '../components/dashboard/state-wrapper';
-import { SummaryCards, type SummaryMetric } from '../components/dashboard/summary-cards';
-import { ZonesOverview, type FarmZone } from '../components/dashboard/zones-overview';
+import { GreenhouseOverviewSection } from "../components/greenhouse-overview-section";
 
-const demoState: DemoState = 'success';
-
-const metrics: SummaryMetric[] = [
-  {
-    label: 'Temperature',
-    value: '24.8°C',
-    trend: '+1.2°C since dawn',
-    status: 'stable',
-  },
-  {
-    label: 'Humidity',
-    value: '68%',
-    trend: 'Ideal seedling range',
-    status: 'good',
-  },
-  {
-    label: 'Soil Moisture',
-    value: '41%',
-    trend: 'Sector B slightly low',
-    status: 'warning',
-  },
-  {
-    label: 'Water Tank',
-    value: '72%',
-    trend: 'Refill projected in 3 days',
-    status: 'good',
-  },
-  {
-    label: 'Device Status',
-    value: '18 / 20 online',
-    trend: '2 sensors need inspection',
-    status: 'warning',
-  },
+const previewItems = [
+  { label: "Primary signal", value: "$128k", detail: "Net uplift since the last release window." },
+  { label: "Momentum", value: "+18%", detail: "Week-on-week momentum across the main surface." },
 ];
 
-const alerts: AlertItem[] = [
-  {
-    title: 'Soil moisture below target in Zone B',
-    detail: 'Moisture dropped to 32% over the last 2 hours.',
-    level: 'warning',
-    time: '10 min ago',
-  },
-  {
-    title: 'Nutrient pump delayed response',
-    detail: 'Pump 02 reported a slow activation cycle during the last run.',
-    level: 'warning',
-    time: '42 min ago',
-  },
-  {
-    title: 'Greenhouse 3 vent reopened',
-    detail: 'Vent system recovered after a brief temperature spike.',
-    level: 'info',
-    time: '1 hr ago',
-  },
-];
-
-const zones: FarmZone[] = [
-  {
-    name: 'Greenhouse A',
-    crop: 'Tomatoes',
-    temperature: '25°C',
-    moisture: 'Healthy',
-    irrigation: 'Scheduled 4:00 PM',
-    status: 'Optimal',
-  },
-  {
-    name: 'Greenhouse B',
-    crop: 'Leafy Greens',
-    temperature: '22°C',
-    moisture: 'Needs water',
-    irrigation: 'Priority queue',
-    status: 'Attention',
-  },
-  {
-    name: 'Orchard West',
-    crop: 'Citrus',
-    temperature: '27°C',
-    moisture: 'Balanced',
-    irrigation: 'Completed 8:15 AM',
-    status: 'Stable',
-  },
-  {
-    name: 'Nursery Bay',
-    crop: 'Seedlings',
-    temperature: '23°C',
-    moisture: 'Protected',
-    irrigation: 'Misting active',
-    status: 'Optimal',
-  },
-];
-
-const stateCopy: Record<DemoState, { title: string; message: string }> = {
-  loading: {
-    title: 'Loading SmartFarm dashboard',
-    message: 'Preparing the latest greenhouse snapshot and alert feed.',
-  },
-  empty: {
-    title: 'No SmartFarm data yet',
-    message: 'Connect sensors or add sample readings to populate this demo view.',
-  },
-  error: {
-    title: 'Dashboard preview unavailable',
-    message: 'We could not load the sample monitoring data. Try refreshing the demo.',
-  },
-  success: {
-    title: 'Farm operations are in view',
-    message: 'A live-style snapshot of climate, irrigation, and sensor activity across your farm.',
-  },
+const pageStyles = {
+  shell: { minHeight: "100vh", padding: "4rem 1.5rem", background: "linear-gradient(180deg, #f5efe4 0%, #ebe4d8 100%)", color: "#1f2937" },
+  hero: { maxWidth: "56rem", margin: "0 auto 2rem", padding: "2rem", borderRadius: "28px", background: "#fffaf0", boxShadow: "0 24px 60px rgba(15, 23, 42, 0.12)" },
+  eyebrow: { margin: 0, textTransform: "uppercase", letterSpacing: "0.18em", fontSize: "0.72rem", color: "#0f766e" },
+  title: { margin: "0.75rem 0 0", fontSize: "clamp(2.5rem, 6vw, 4.75rem)", lineHeight: 0.95 },
+  description: { maxWidth: "42rem", margin: "1rem 0 0", fontSize: "1.05rem", color: "#5b6470" },
 };
 
-const stateOrder: DemoState[] = ['success', 'loading', 'empty', 'error'];
-
-function DashboardContent({ currentState }: { currentState: DemoState }) {
-  const currentAlerts = currentState === 'empty' ? [] : alerts;
-  const currentZones = currentState === 'empty' ? [] : zones;
-
+export default function HomePage() {
   return (
-    <StateWrapper
-      state={currentState}
-      emptyTitle="No live farm readings"
-      emptyMessage="Summary cards stay visible for context, while alerts and zones show how empty dashboard sections are presented."
-      errorTitle="Dashboard content unavailable"
-      errorMessage="This in-page example demonstrates an inline error state alongside route-level error boundaries."
-    >
-      <section className="dashboard-grid" aria-label="SmartFarm dashboard overview">
-        <div className="dashboard-main">
-          <SummaryCards metrics={metrics} />
-          {currentZones.length === 0 ? (
-            <section className="dashboard-panel">
-              <div className="empty-panel">
-                <strong>No zones configured</strong>
-                <p>Add greenhouses or irrigation zones to populate this overview.</p>
-              </div>
-            </section>
-          ) : (
-            <ZonesOverview zones={currentZones} />
-          )}
-        </div>
-        <div className="dashboard-side">
-          <AlertsPanel alerts={currentAlerts} />
-        </div>
+    <main style={pageStyles.shell}>
+      <section style={pageStyles.hero}>
+        <p style={pageStyles.eyebrow}>Signal-rich dashboard</p>
+        <h1 style={pageStyles.title}>Home</h1>
+        <p style={pageStyles.description}>A bold control room layout with clear hierarchy, warm surfaces, and decisive contrast.</p>
       </section>
-    </StateWrapper>
-  );
-}
-
-export default function Page() {
-  return (
-    <main className="page-shell">
-      <section className="hero-card">
-        <div>
-          <span className="eyebrow">SmartFarm demo</span>
-          <h1>{stateCopy[demoState].title}</h1>
-          <p>{stateCopy[demoState].message}</p>
-        </div>
-        <div className="hero-meta">
-          <div className="hero-pill">Primary mode: {demoState}</div>
-          <div className="hero-pill accent">Responsive sample dashboard</div>
-        </div>
-      </section>
-
-      <DashboardContent currentState={demoState} />
-
-      <section className="state-showcase" aria-label="Dashboard UI states showcase">
-        {stateOrder.map((state) => {
-          const copy = stateCopy[state];
-
-          return (
-            <article key={state} className="state-showcase-card">
-              <div className="panel-header">
-                <div>
-                  <span className="eyebrow">State preview</span>
-                  <h2>{copy.title}</h2>
-                </div>
-                <span className="hero-pill">{state}</span>
-              </div>
-              <p className="state-showcase-copy">{copy.message}</p>
-              <DashboardContent currentState={state} />
-            </article>
-          );
-        })}
-      </section>
+      <GreenhouseOverviewSection state="ready" items={previewItems} />
     </main>
   );
 }

--- a/components/dashboard/alerts-panel.tsx
+++ b/components/dashboard/alerts-panel.tsx
@@ -1,0 +1,134 @@
+export type AlertItem = {
+  title: string;
+  detail: string;
+  level: "warning" | "info" | "critical";
+  time: string;
+};
+
+type AlertsPanelProps = {
+  alerts: AlertItem[];
+};
+
+const levelStyles: Record<AlertItem["level"], { background: string; color: string }> = {
+  warning: { background: "rgba(245, 158, 11, 0.14)", color: "#b45309" },
+  info: { background: "rgba(20, 184, 166, 0.12)", color: "#0f766e" },
+  critical: { background: "rgba(239, 68, 68, 0.12)", color: "#b91c1c" },
+};
+
+export function AlertsPanel({ alerts }: AlertsPanelProps) {
+  return (
+    <section
+      aria-labelledby="alerts-title"
+      style={{
+        display: "grid",
+        gap: "1rem",
+        padding: "clamp(1rem, 2.5vw, 1.35rem)",
+        borderRadius: "24px",
+        background: "rgba(255, 250, 240, 0.92)",
+        boxShadow: "0 18px 45px rgba(15, 23, 42, 0.08)",
+        border: "1px solid rgba(148, 163, 184, 0.14)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: "0.75rem",
+        }}
+      >
+        <div>
+          <span
+            style={{
+              display: "inline-block",
+              marginBottom: "0.45rem",
+              textTransform: "uppercase",
+              letterSpacing: "0.16em",
+              fontSize: "0.72rem",
+              color: "#0f766e",
+              fontWeight: 700,
+            }}
+          >
+            Recent alerts
+          </span>
+          <h2 id="alerts-title" style={{ margin: 0, fontSize: "1.2rem", color: "#1f2937" }}>
+            Attention feed
+          </h2>
+        </div>
+        <span
+          style={{
+            padding: "0.5rem 0.8rem",
+            borderRadius: "999px",
+            background: "rgba(15, 118, 110, 0.1)",
+            color: "#115e59",
+            fontWeight: 700,
+            fontSize: "0.84rem",
+          }}
+        >
+          {alerts.length} active
+        </span>
+      </div>
+
+      {alerts.length === 0 ? (
+        <div
+          style={{
+            padding: "1rem",
+            borderRadius: "18px",
+            background: "linear-gradient(135deg, rgba(236, 253, 245, 0.8), rgba(254, 249, 195, 0.75))",
+            border: "1px dashed rgba(34, 197, 94, 0.24)",
+            color: "#166534",
+          }}
+        >
+          <strong style={{ display: "block", marginBottom: "0.35rem" }}>No active alerts</strong>
+          <p style={{ margin: 0, lineHeight: 1.55 }}>
+            All monitored zones are within the expected range. This empty state is intentionally compact so it reads well on mobile and desktop alike.
+          </p>
+        </div>
+      ) : (
+        <div style={{ display: "grid", gap: "0.85rem" }}>
+          {alerts.map((alert) => (
+            <article
+              key={`${alert.title}-${alert.time}`}
+              style={{
+                display: "grid",
+                gap: "0.65rem",
+                padding: "1rem",
+                borderRadius: "18px",
+                background: "rgba(255,255,255,0.72)",
+                border: "1px solid rgba(148, 163, 184, 0.12)",
+              }}
+            >
+              <div
+                style={{
+                  display: "flex",
+                  flexWrap: "wrap",
+                  justifyContent: "space-between",
+                  gap: "0.6rem",
+                  alignItems: "center",
+                }}
+              >
+                <span
+                  style={{
+                    ...levelStyles[alert.level],
+                    padding: "0.35rem 0.7rem",
+                    borderRadius: "999px",
+                    fontSize: "0.75rem",
+                    fontWeight: 700,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.04em",
+                  }}
+                >
+                  {alert.level}
+                </span>
+                <span style={{ color: "#6b7280", fontSize: "0.9rem", fontWeight: 600 }}>{alert.time}</span>
+              </div>
+              <h3 style={{ margin: 0, fontSize: "1rem", color: "#1f2937" }}>{alert.title}</h3>
+              <p style={{ margin: 0, color: "#5b6470", lineHeight: 1.55 }}>{alert.detail}</p>
+            </article>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/components/dashboard/state-wrapper.tsx
+++ b/components/dashboard/state-wrapper.tsx
@@ -1,0 +1,142 @@
+import type { CSSProperties, ReactNode } from "react";
+
+export type DemoState = "loading" | "empty" | "error" | "success";
+
+type StateWrapperProps = {
+  state: DemoState;
+  children: ReactNode;
+  loadingTitle?: string;
+  loadingMessage?: string;
+  emptyTitle?: string;
+  emptyMessage?: string;
+  errorTitle?: string;
+  errorMessage?: string;
+};
+
+const stateContent: Record<DemoState, { title: string; message: string }> = {
+  loading: {
+    title: "Loading SmartFarm view",
+    message: "Preparing greenhouse metrics, alerts, and zone summaries.",
+  },
+  empty: {
+    title: "No farm activity to show",
+    message: "This demo state shows how the dashboard looks when there are no recent readings or alerts.",
+  },
+  error: {
+    title: "Sample data preview failed",
+    message: "This demo state represents an in-page fallback when dashboard content cannot be shown.",
+  },
+  success: {
+    title: "",
+    message: "",
+  },
+};
+
+const accentStyles: Record<Exclude<DemoState, "success">, CSSProperties> = {
+  loading: {
+    background: "linear-gradient(135deg, rgba(250, 204, 21, 0.18), rgba(245, 158, 11, 0.14))",
+    border: "1px solid rgba(245, 158, 11, 0.28)",
+    color: "#92400e",
+  },
+  empty: {
+    background: "linear-gradient(135deg, rgba(254, 243, 199, 0.72), rgba(220, 252, 231, 0.7))",
+    border: "1px solid rgba(34, 197, 94, 0.18)",
+    color: "#166534",
+  },
+  error: {
+    background: "linear-gradient(135deg, rgba(254, 226, 226, 0.88), rgba(255, 247, 237, 0.92))",
+    border: "1px solid rgba(239, 68, 68, 0.22)",
+    color: "#991b1b",
+  },
+};
+
+export function StateWrapper({
+  state,
+  children,
+  loadingTitle,
+  loadingMessage,
+  emptyTitle,
+  emptyMessage,
+  errorTitle,
+  errorMessage,
+}: StateWrapperProps) {
+  if (state === "success") {
+    return <>{children}</>;
+  }
+
+  const content = stateContent[state];
+
+  const title =
+    state === "loading"
+      ? loadingTitle ?? content.title
+      : state === "empty"
+        ? emptyTitle ?? content.title
+        : errorTitle ?? content.title;
+
+  const message =
+    state === "loading"
+      ? loadingMessage ?? content.message
+      : state === "empty"
+        ? emptyMessage ?? content.message
+        : errorMessage ?? content.message;
+
+  const helperCopy =
+    state === "loading"
+      ? "Skeleton cards and sections are arranged to preview the dashboard at both compact mobile and wide desktop breakpoints."
+      : state === "empty"
+        ? "The empty state keeps its message concise so it remains easy to scan on mobile while still feeling balanced on desktop."
+        : "The inline fallback is designed to stay readable in stacked and multi-column layouts, with a warmer alert treatment that stays visible on phones and larger screens.";
+
+  return (
+    <section
+      aria-live="polite"
+      style={{
+        display: "grid",
+        gap: "1rem",
+        width: "100%",
+        boxSizing: "border-box",
+        padding: "clamp(1rem, 3vw, 1.5rem)",
+        borderRadius: "24px",
+        ...accentStyles[state],
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          justifyContent: "space-between",
+          gap: "0.75rem",
+          alignItems: "center",
+        }}
+      >
+        <div
+          style={{
+            padding: "0.35rem 0.7rem",
+            borderRadius: "999px",
+            background: "rgba(255,255,255,0.45)",
+            fontSize: "0.78rem",
+            fontWeight: 700,
+            textTransform: "uppercase",
+            letterSpacing: "0.05em",
+          }}
+        >
+          {state} state
+        </div>
+        <div
+          style={{
+            fontSize: "0.85rem",
+            fontWeight: 600,
+            opacity: 0.9,
+          }}
+        >
+          Mobile and desktop ready
+        </div>
+      </div>
+      <div style={{ display: "grid", gap: "0.65rem" }}>
+        <h3 style={{ margin: 0 }}>{title}</h3>
+        <p style={{ margin: 0, lineHeight: 1.55 }}>{message}</p>
+        <p style={{ margin: 0, lineHeight: 1.55 }}>{helperCopy}</p>
+      </div>
+    </section>
+  );
+}

--- a/components/dashboard/summary-cards.tsx
+++ b/components/dashboard/summary-cards.tsx
@@ -1,0 +1,27 @@
+export type SummaryMetric = {
+  label: string;
+  value: string;
+  trend: string;
+  status: 'good' | 'warning' | 'stable';
+};
+
+type SummaryCardsProps = {
+  metrics: SummaryMetric[];
+};
+
+export function SummaryCards({ metrics }: SummaryCardsProps) {
+  return (
+    <section className="summary-grid" aria-label="Farm summary metrics">
+      {metrics.map((metric) => (
+        <article key={metric.label} className="summary-card">
+          <div className="summary-card-top">
+            <span className="summary-label">{metric.label}</span>
+            <span className={`status-badge ${metric.status}`}>{metric.status}</span>
+          </div>
+          <strong className="summary-value">{metric.value}</strong>
+          <p className="summary-trend">{metric.trend}</p>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/components/dashboard/zones-overview.tsx
+++ b/components/dashboard/zones-overview.tsx
@@ -1,0 +1,54 @@
+export type FarmZone = {
+  name: string;
+  crop: string;
+  temperature: string;
+  moisture: string;
+  irrigation: string;
+  status: string;
+};
+
+type ZonesOverviewProps = {
+  zones: FarmZone[];
+};
+
+export function ZonesOverview({ zones }: ZonesOverviewProps) {
+  return (
+    <section className="dashboard-panel" aria-labelledby="zones-title">
+      <div className="panel-header">
+        <div>
+          <span className="eyebrow">Farm zones</span>
+          <h2 id="zones-title">Greenhouse overview</h2>
+        </div>
+        <span className="hero-pill accent">{zones.length} zones</span>
+      </div>
+
+      <div className="zones-grid">
+        {zones.map((zone) => (
+          <article key={zone.name} className="zone-card">
+            <div className="zone-header">
+              <div>
+                <h3>{zone.name}</h3>
+                <p>{zone.crop}</p>
+              </div>
+              <span className="status-badge stable">{zone.status}</span>
+            </div>
+            <dl className="zone-stats">
+              <div>
+                <dt>Temperature</dt>
+                <dd>{zone.temperature}</dd>
+              </div>
+              <div>
+                <dt>Moisture</dt>
+                <dd>{zone.moisture}</dd>
+              </div>
+              <div>
+                <dt>Irrigation</dt>
+                <dd>{zone.irrigation}</dd>
+              </div>
+            </dl>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/greenhouse-overview-section.tsx
+++ b/components/greenhouse-overview-section.tsx
@@ -1,0 +1,73 @@
+type GreenhouseOverviewSectionState = "loading" | "empty" | "error" | "ready";
+
+type GreenhouseOverviewSectionItem = {
+  label: string;
+  value: string;
+  detail?: string;
+};
+
+type GreenhouseOverviewSectionProps = {
+  state?: GreenhouseOverviewSectionState;
+  items?: GreenhouseOverviewSectionItem[];
+};
+
+const sectionStyles = {
+  shell: { borderRadius: "28px", padding: "1.5rem", background: "#fffaf0", color: "#1f2937", boxShadow: "0 24px 60px rgba(15, 23, 42, 0.12)" },
+  eyebrow: { margin: 0, textTransform: "uppercase", letterSpacing: "0.16em", fontSize: "0.72rem", color: "#0f766e" },
+  title: { margin: "0.5rem 0 0", fontSize: "1.5rem" },
+  description: { margin: "0.75rem 0 0", color: "#5b6470" },
+  grid: { display: "grid", gap: "1rem", gridTemplateColumns: "repeat(auto-fit, minmax(12rem, 1fr))", marginTop: "1.5rem" },
+  card: { padding: "1rem", borderRadius: "20px", background: "#f0e7d8" },
+  value: { margin: "0.35rem 0 0", fontSize: "1.9rem", color: "#1f2937" },
+  detail: { margin: "0.5rem 0 0", color: "#5b6470", fontSize: "0.95rem" },
+  statePanel: { marginTop: "1.5rem", padding: "1.25rem", borderRadius: "20px", background: "#f0e7d8", color: "#5b6470" },
+};
+
+export function GreenhouseOverviewSection({ state = "ready", items = [] }: GreenhouseOverviewSectionProps) {
+  if (state === "loading") {
+    return (
+      <section style={sectionStyles.shell}>
+        <p style={sectionStyles.eyebrow}>Signal-rich dashboard</p>
+        <h2 style={sectionStyles.title}>Greenhouse Overview Section</h2>
+        <p style={sectionStyles.description}>Loading the latest signals and arranging the board.</p>
+      </section>
+    );
+  }
+
+  if (state === "error") {
+    return (
+      <section style={sectionStyles.shell}>
+        <p style={sectionStyles.eyebrow}>Signal-rich dashboard</p>
+        <h2 style={sectionStyles.title}>Greenhouse Overview Section</h2>
+        <div style={sectionStyles.statePanel}>The page is intact, but the live content could not be refreshed just now.</div>
+      </section>
+    );
+  }
+
+  if (state === "empty" || items.length === 0) {
+    return (
+      <section style={sectionStyles.shell}>
+        <p style={sectionStyles.eyebrow}>Signal-rich dashboard</p>
+        <h2 style={sectionStyles.title}>Greenhouse Overview Section</h2>
+        <div style={sectionStyles.statePanel}>No highlights are available yet. Connect a data source or publish the first event.</div>
+      </section>
+    );
+  }
+
+  return (
+    <section style={sectionStyles.shell}>
+      <p style={sectionStyles.eyebrow}>Signal-rich dashboard</p>
+      <h2 style={sectionStyles.title}>Greenhouse Overview Section</h2>
+      <p style={sectionStyles.description}>Designed to surface the strongest numbers first while still leaving room for narrative context.</p>
+      <div style={sectionStyles.grid}>
+        {items.map((item) => (
+          <article key={item.label} style={sectionStyles.card}>
+            <p style={sectionStyles.eyebrow}>{item.label}</p>
+            <p style={sectionStyles.value}>{item.value}</p>
+            {item.detail ? <p style={sectionStyles.detail}>{item.detail}</p> : null}
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,488 @@
+{
+  "name": "smartfarm-dashboard",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "smartfarm-dashboard",
+      "version": "0.1.0",
+      "dependencies": {
+        "next": "14.2.16",
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
+      },
+      "devDependencies": {
+        "@types/node": "22.9.0",
+        "@types/react": "18.3.12",
+        "typescript": "5.6.3"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.16.tgz",
+      "integrity": "sha512-fLrX5TfJzHCbnZ9YUSnGW63tMV3L4nSfhgOQ0iCcX21Pt+VSTDuaLsSuL8J/2XAiVA5AnzvXDpf6pMs60QxOag==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.16.tgz",
+      "integrity": "sha512-uFT34QojYkf0+nn6MEZ4gIWQ5aqGF11uIZ1HSxG+cSbj+Mg3+tYm8qXYd3dKN5jqKUm5rBVvf1PBRO/MeQ6rxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.16.tgz",
+      "integrity": "sha512-mCecsFkYezem0QiZlg2bau3Xul77VxUD38b/auAjohMA22G9KTJneUYMv78vWoCCFkleFAhY1NIvbyjj1ncG9g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.16.tgz",
+      "integrity": "sha512-yhkNA36+ECTC91KSyZcgWgKrYIyDnXZj8PqtJ+c2pMvj45xf7y/HrgI17hLdrcYamLfVt7pBaJUMxADtPaczHA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.16.tgz",
+      "integrity": "sha512-X2YSyu5RMys8R2lA0yLMCOCtqFOoLxrq2YbazFvcPOE4i/isubYjkh+JCpRmqYfEuCVltvlo+oGfj/b5T2pKUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.16.tgz",
+      "integrity": "sha512-9AGcX7VAkGbc5zTSa+bjQ757tkjr6C/pKS7OK8cX7QEiK6MHIIezBLcQ7gQqbDW2k5yaqba2aDtaBeyyZh1i6Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.16.tgz",
+      "integrity": "sha512-Klgeagrdun4WWDaOizdbtIIm8khUDQJ/5cRzdpXHfkbY91LxBXeejL4kbZBrpR/nmgRrQvmz4l3OtttNVkz2Sg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.16.tgz",
+      "integrity": "sha512-PwW8A1UC1Y0xIm83G3yFGPiOBftJK4zukTmk7DI1CebyMOoaVpd8aSy7K6GhobzhkjYvqS/QmzcfsWG2Dwizdg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.16.tgz",
+      "integrity": "sha512-jhPl3nN0oKEshJBNDAo0etGMzv0j3q3VYorTSFqH1o3rwv1MQRdor27u1zhkgsHPNeY1jxcgyx1ZsCkDD1IHgg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.16.tgz",
+      "integrity": "sha512-OA7NtfxgirCjfqt+02BqxC3MIgM/JaGjw9tOe4fyZgPsqfseNiMPnCRP44Pfs+Gpo9zPN+SXaFsgP6vk8d571A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.9.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.8"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.12",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.12.tgz",
+      "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001777",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
+      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.16",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.16.tgz",
+      "integrity": "sha512-LcO7WnFu6lYSvCzZoo1dB+IO0xXz5uEv52HF1IUN0IqVTUIZGHuuR10I5efiLadGt+4oZqTcNZyVVEem/TM5nA==",
+      "deprecated": "This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.16",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.16",
+        "@next/swc-darwin-x64": "14.2.16",
+        "@next/swc-linux-arm64-gnu": "14.2.16",
+        "@next/swc-linux-arm64-musl": "14.2.16",
+        "@next/swc-linux-x64-gnu": "14.2.16",
+        "@next/swc-linux-x64-musl": "14.2.16",
+        "@next/swc-win32-arm64-msvc": "14.2.16",
+        "@next/swc-win32-ia32-msvc": "14.2.16",
+        "@next/swc-win32-x64-msvc": "14.2.16"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "smartfarm-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "next": "14.2.16",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "typescript": "5.6.3",
+    "@types/react": "18.3.12",
+    "@types/node": "22.9.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- Run ID: 20260308T131205Z-6841fe78
- Branch: ai-code-agent/gh-1-create-smartfarm-sample-dashboard
- Patches generated: 4
- Retry count: 0

## Plan
- Inspect the current App Router pages and any existing dashboard-related components to determine whether the SmartFarm dashboard should live on `app/page.tsx`, `app/github/page.tsx`, or both, and whether candidate dashboard components already exist or need completion. - Implement or refine a SmartFarm dashboard page using static sample data, prioritizing the relevant route file(s) under `app/` and composing shared UI from `components/` where helpful. - Add a clean responsive layout with summary metric cards for temperature, humidity, soil moisture, water tank level, and device status, using warm dashboard styling appropriate for desktop and mobile. - Add a recent alerts section populated with sample warning items and a farm zones/greenhouse overview section showing simple zone status and key readings. - Include explicit demo-friendly UI states: success (normal dashboard content), loading (route-level loading skeleton/spinner via `app/loading.tsx` and/or `app/github/loading.tsx`), error (route-level error UI via `app/error.tsx` and/or `app/github/error.tsx`), and empty state handling inside dashboard sections when arrays such as alerts or zones are empty. - If shared components alr

## Changed Areas
- app/error.tsx
- app/loading.tsx
- app/page.tsx
- components/greenhouse-overview-section.tsx